### PR TITLE
Adds gemspec to root folder, fix #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 pkg
-*.gemspec
 Gemfile.lock
 demo/assets

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ end
 #
 # To publish your gem online, install the 'gemcutter' gem; Read more
 # about that here: http://gemcutter.org/pages/gem_docs
-spec = File.read("ruby2js.gemspec")
+spec = eval File.read("ruby2js.gemspec")
 
 Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec

--- a/Rakefile
+++ b/Rakefile
@@ -14,41 +14,16 @@ end
 #
 #   http://rubygems.org/read/chapter/20
 #
-spec = Gem::Specification.new do |s|
-
-  # Change these as appropriate
-  s.name           = "ruby2js"
-  s.license        = 'MIT'
-  s.version        = Ruby2JS::VERSION::STRING
-  s.summary        = "Minimal yet extensible Ruby to JavaScript conversion."
-  s.author         = "Sam Ruby"
-  s.email          = "rubys@intertwingly.net"
-  s.homepage       = "http://github.com/rubys/ruby2js"
-  s.description    = <<-EOD
-    The base package maps Ruby syntax to JavaScript semantics.
-    Filters may be provided to add Ruby-specific or framework specific
-    behavior.
-  EOD
-
-  # Add any extra files to include in the gem
-  s.files             = %w(ruby2js.gemspec README.md) + Dir.glob("{lib}/**/*")
-  s.require_paths     = ["lib"]
-
-  # If you want to depend on other gems, add them here, along with any
-  # relevant versions
-  s.add_dependency("parser")
-
-  # Require Ruby 1.9.3 or greater
-  s.required_ruby_version = '>= 1.9.3'
-end
 
 # This task actually builds the gem. We also regenerate a static
 # .gemspec file, which is useful if something (i.e. GitHub) will
 # be automatically building a gem for this project. If you're not
 # using GitHub, edit as appropriate.
 #
-# To publish your gem online, install the 'gemcutter' gem; Read more 
+# To publish your gem online, install the 'gemcutter' gem; Read more
 # about that here: http://gemcutter.org/pages/gem_docs
+spec = File.read("ruby2js.gemspec")
+
 Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end

--- a/ruby2js.gemspec
+++ b/ruby2js.gemspec
@@ -1,0 +1,31 @@
+# coding: utf-8
+$:.push File.expand_path("../lib", __FILE__)
+require "ruby2js/version"
+
+Gem::Specification.new do |s|
+
+  # Change these as appropriate
+  s.name           = "ruby2js"
+  s.license        = 'MIT'
+  s.version        = Ruby2JS::VERSION::STRING
+  s.summary        = "Minimal yet extensible Ruby to JavaScript conversion."
+  s.author         = "Sam Ruby"
+  s.email          = "rubys@intertwingly.net"
+  s.homepage       = "http://github.com/rubys/ruby2js"
+  s.description    = <<-EOD
+    The base package maps Ruby syntax to JavaScript semantics.
+    Filters may be provided to add Ruby-specific or framework specific
+    behavior.
+  EOD
+
+  # Add any extra files to include in the gem
+  s.files             = %w(ruby2js.gemspec README.md) + Dir.glob("{lib}/**/*")
+  s.require_paths     = ["lib"]
+
+  # If you want to depend on other gems, add them here, along with any
+  # relevant versions
+  s.add_dependency("parser")
+
+  # Require Ruby 1.9.3 or greater
+  s.required_ruby_version = '>= 1.9.3'
+end


### PR DESCRIPTION
Just externalise the spec to a file to be used by bundler
(old rake tasks still work, but see note about using bundlers) 