### PR TITLE
Remove unnecessary array length call when ruby slice arguments are negative

### DIFF
--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -280,17 +280,19 @@ module Ruby2JS
 
           elsif index.type == :irange
             start, finish = index.children
-            start = i.(start)
             if finish.type == :int
-              if finish.children.first == -1
-                finish = S(:attr, target, :length)
-              else
-                finish = S(:int, finish.children.first+1)
-              end
+              final = S(:int, finish.children.first+1)
             else
-              finish = S(:send, finish, :+, s(:int, 1))
+              final = S(:send, finish, :+, s(:int, 1))
             end
-            process S(:send, target, :slice, start, finish)
+
+            # No need for the last argument if it's -1
+            # This means take all to the end of array
+            if finish.children.first == -1
+              process S(:send, target, :slice, start)
+            else
+              process S(:send, target, :slice, start, final)
+            end
 
           else
             super

--- a/lib/ruby2js/filter/functions.rb
+++ b/lib/ruby2js/filter/functions.rb
@@ -285,7 +285,7 @@ module Ruby2JS
               if finish.children.first == -1
                 finish = S(:attr, target, :length)
               else
-                finish = i.(S(:int, finish.children.first+1))
+                finish = S(:int, finish.children.first+1)
               end
             else
               finish = S(:send, finish, :+, s(:int, 1))

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -143,7 +143,8 @@ describe Ruby2JS::Filter::Functions do
     it "should handle inclusive ranges" do
       to_js( 'a[2..4]' ).must_equal 'a.slice(2, 5)'
       to_js( 'a[2..-1]' ).must_equal 'a.slice(2, a.length)'
-      to_js( 'a[-4..-2]' ).must_equal 'a.slice(a.length - 4, a.length - 1)'
+      to_js( 'a[-4..-2]' ).must_equal 'a.slice(a.length - 4, -1)'
+      to_js( 'a[-4..-3]' ).must_equal 'a.slice(a.length - 4, -2)'
     end
 
     it "should handle exclusive ranges" do

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -142,9 +142,10 @@ describe Ruby2JS::Filter::Functions do
 
     it "should handle inclusive ranges" do
       to_js( 'a[2..4]' ).must_equal 'a.slice(2, 5)'
-      to_js( 'a[2..-1]' ).must_equal 'a.slice(2, a.length)'
-      to_js( 'a[-4..-2]' ).must_equal 'a.slice(a.length - 4, -1)'
-      to_js( 'a[-4..-3]' ).must_equal 'a.slice(a.length - 4, -2)'
+      to_js( 'a[2..-1]' ).must_equal 'a.slice(2)'
+      to_js( 'a[-2..-1]' ).must_equal 'a.slice(-2)'
+      to_js( 'a[-4..-2]' ).must_equal 'a.slice(-4, -1)'
+      to_js( 'a[-4..-3]' ).must_equal 'a.slice(-4, -2)'
     end
 
     it "should handle exclusive ranges" do


### PR DESCRIPTION
After merging this following ruby code:
```ruby
[1,2,3,4][1..-2]
```
Converts now into:
```js
[1, 2, 3, 4].slice(1, -1)
```
Instead of:
```js
[1, 2, 3, 4].slice(1, [1,2,3,4].length - 1)
```

The length is unnecessary when the final argument is -2 or smaller according to `slice` documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice