### PR TITLE
Fix interaction between autoreturn and camelCase

### DIFF
--- a/lib/ruby2js/filter/return.rb
+++ b/lib/ruby2js/filter/return.rb
@@ -8,11 +8,11 @@ module Ruby2JS
       EXPRESSIONS = [ :array, :float, :hash, :if, :int, :lvar, :nil, :send ]
 
       def on_block(node)
-        children = process_all(node.children)
+        all_children = children = process_all(node.children)
 
         children[-1] = s(:nil) if children.last == nil
 
-        node.updated nil, [*node.children[0..1],
+        node.updated nil, [*all_children[0..1],
           s(:autoreturn, *children[2..-1])]
       end
 

--- a/spec/camelcase_spec.rb
+++ b/spec/camelcase_spec.rb
@@ -61,7 +61,8 @@ describe Ruby2JS::Filter::CamelCase do
     end
 
     it "should work with autoreturn filter" do
-      to_js_with_autoreturn( 'foo_bar(123) { x }' ).must_equal 'fooBar(123, function() {return x})'
+      to_js_with_autoreturn( 'foo_bar(123) {|a_b_c| x }' ).
+        must_equal 'fooBar(123, function(aBC) {return x})'
     end
   end
 

--- a/spec/camelcase_spec.rb
+++ b/spec/camelcase_spec.rb
@@ -7,7 +7,12 @@ describe Ruby2JS::Filter::CamelCase do
   def to_js( string)
     _(Ruby2JS.convert(string, filters: [Ruby2JS::Filter::CamelCase]).to_s)
   end
-  
+
+  def to_js_with_autoreturn(string)
+    require 'ruby2js/filter/return'
+    _(Ruby2JS.convert(string, filters: [Ruby2JS::Filter::CamelCase, Ruby2JS::Filter::Return]).to_s)
+  end
+ 
   describe :camelCase do
     it "should handle variables" do
       to_js( 'foo_bar=baz_qux' ).must_equal 'var fooBar = bazQux'
@@ -53,6 +58,10 @@ describe Ruby2JS::Filter::CamelCase do
 
     it "should handle hashes" do
       to_js( '{foo_bar: 1}' ).must_equal '{fooBar: 1}'
+    end
+
+    it "should work with autoreturn filter" do
+      to_js_with_autoreturn( 'foo_bar(123) { x }' ).must_equal 'fooBar(123, function() {return x})'
     end
   end
 


### PR DESCRIPTION
Before, with both the return and camelCase filters enabled, it wasn't working in situations involving blocks:

```ruby
foo_bar(123) {|a_b_c| x }
# => foo_bar(123, function(a_b_c) {return x})
```

This fixes it so the camel casing still works:

```ruby
foo_bar(123) {|a_b_c| x }
# => fooBar(123, function(aBC) {return x})
```