### PR TITLE
Don't reorder camelCase filter for demo args

### DIFF
--- a/demo/ruby2js.rb
+++ b/demo/ruby2js.rb
@@ -63,9 +63,6 @@ begin
     filters[filter] = "ruby2js/filter/#{filter}"
   end
 
-  # put camelCase last as it may interfere with other filters
-  filters['camelCase'] = filters.delete('camelCase')
-
   # allow filters to be selected based on the path
   selected = env['PATH_INFO'].to_s.split('/')
 


### PR DESCRIPTION
I thought this would be better as a PR so we can discuss this. Basically the camelCase filter was being forced to the end of the filter list for the demo app with a comment that there might be weird filter interactions otherwise, but I found a case where the opposite was true: having it after the return filter stopped it from handling def nodes. That's probably a bug in the return filter which needs fixing, but the point is I don't necessarily think camelCase should be forced to the end of the filters list by the demo app (and it so happens I'm including it near the beginning of the list so far on my projects).

Let me know what you think about this change, thanks!