### PR TITLE
Add configuration option to underscore private fields even in es2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Emit nullish coalescing operators:
 puts Ruby2JS.convert('a || 1', or: :nullish)
 ```
 
+Emit underscored private fields (allowing subclass access):
+
+```ruby
+puts Ruby2JS.convert('class C; def initialize; @f=1; end; end',
+  eslevel: 2020, underscored_private: true)
+```
+
 With [ExecJS](https://github.com/sstephenson/execjs):
 ```ruby
 require 'ruby2js/execjs'

--- a/demo/ruby2js.rb
+++ b/demo/ruby2js.rb
@@ -41,6 +41,7 @@ options[:comparison] = :identity if ARGV.delete('--identity')
 options[:or] = :logical if ARGV.delete('--logical')
 options[:or] = :nullish if ARGV.delete('--nullish')
 options[:include] = :class if ARGV.delete('--include-class')
+options[:underscored_private] = true if ARGV.delete('--underscored-private')
 
 begin
   # support running directly from a git clone

--- a/lib/ruby2js.rb
+++ b/lib/ruby2js.rb
@@ -203,6 +203,7 @@ module Ruby2JS
     ruby2js.strict = options[:strict]
     ruby2js.comparison = options[:comparison] || :equality
     ruby2js.or = options[:or] || :logical
+    ruby2js.underscored_private = (options[:eslevel] < 2020) || options[:underscored_private]
     if ruby2js.binding and not ruby2js.ivars
       ruby2js.ivars = ruby2js.binding.eval \
         'Hash[instance_variables.map {|var| [var, instance_variable_get(var)]}]'

--- a/lib/ruby2js/converter.rb
+++ b/lib/ruby2js/converter.rb
@@ -63,6 +63,7 @@ module Ruby2JS
       @strict = false
       @comparison = :equality
       @or = :logical
+      @underscored_private = true
     end
 
     def width=(width)
@@ -127,7 +128,7 @@ module Ruby2JS
       Parser::AST::Node.new(type, args)
     end
 
-    attr_accessor :strict, :eslevel, :comparison, :or
+    attr_accessor :strict, :eslevel, :comparison, :or, :underscored_private
 
     def es2015
       @eslevel >= 2015

--- a/lib/ruby2js/converter/class2.rb
+++ b/lib/ruby2js/converter/class2.rb
@@ -49,7 +49,7 @@ module Ruby2JS
         end
 
         # private variable declarations
-        if es2020
+        unless underscored_private
           ivars = Set.new
           cvars = Set.new
 
@@ -202,7 +202,7 @@ module Ruby2JS
             end
 
           elsif m.type == :send and m.children.first == nil
-            p = es2020 ? '#' : '_'
+            p = underscored_private ? '_' : '#'
 
             if m.children[1] == :attr_accessor
               m.children[2..-1].each_with_index do |child_sym, index2|
@@ -236,7 +236,7 @@ module Ruby2JS
             end
 
           else
-            if m.type == :cvasgn and es2020
+            if m.type == :cvasgn and !underscored_private
               put 'static #$'; put m.children[0].to_s[2..-1]; put ' = '
               parse m.children[1]
             else

--- a/lib/ruby2js/converter/cvar.rb
+++ b/lib/ruby2js/converter/cvar.rb
@@ -4,7 +4,7 @@ module Ruby2JS
     # (cvar :@@a)
 
     handle :cvar do |var|
-      prefix = es2020 ? '#$' : '_'
+      prefix = underscored_private ? '_' : '#$'
 
       @class_name ||= nil
       if @class_name

--- a/lib/ruby2js/converter/cvasgn.rb
+++ b/lib/ruby2js/converter/cvasgn.rb
@@ -7,7 +7,7 @@ module Ruby2JS
     handle :cvasgn do |var, expression=nil|
       multi_assign_declarations if @state == :statement
 
-      prefix = es2020 ? '#$' : '_'
+      prefix = underscored_private ? '_' : '#$'
 
       if @class_name
         parse @class_name

--- a/lib/ruby2js/converter/ivar.rb
+++ b/lib/ruby2js/converter/ivar.rb
@@ -6,10 +6,10 @@ module Ruby2JS
     handle :ivar do |var|
       if self.ivars and self.ivars.include? var
         parse s(:hostvalue, self.ivars[var])
-      elsif es2020
-        parse s(:attr, s(:self), var.to_s.sub('@', '#'))
-      else
+      elsif underscored_private
         parse s(:attr, s(:self), var.to_s.sub('@', '_'))
+      else
+        parse s(:attr, s(:self), var.to_s.sub('@', '#'))
       end
     end
 

--- a/lib/ruby2js/converter/ivasgn.rb
+++ b/lib/ruby2js/converter/ivasgn.rb
@@ -7,7 +7,7 @@ module Ruby2JS
     handle :ivasgn do |var, expression=nil|
       multi_assign_declarations if @state == :statement
 
-      put "#{ var.to_s.sub('@', 'this.' + (es2020 ? '#' : '_')) }"
+      put "#{ var.to_s.sub('@', 'this.' + (underscored_private ? '_' : '#')) }"
       if expression
         put " = "; parse expression
       end

--- a/lib/ruby2js/filter/camelCase.rb
+++ b/lib/ruby2js/filter/camelCase.rb
@@ -23,6 +23,9 @@ module Ruby2JS
 
         if node.children[0] == nil and WHITELIST.include? node.children[1].to_s
           node
+        elsif node.children[0] && [:ivar, :cvar].include?(node.children[0].type)
+          S(node.type, s(node.children[0].type, camelCase(node.children[0].children[0])),
+            camelCase(node.children[1]), *node.children[2..-1])
         elsif node.children[1] =~ /_.*\w[=!?]?$/
           S(node.type, node.children[0],
             camelCase(node.children[1]), *node.children[2..-1])
@@ -68,6 +71,28 @@ module Ruby2JS
         end
       end
 
+      def on_ivar(node)
+        node = super
+        return node if node.type != :ivar
+
+        if node.children[0] =~ /_.*\w$/
+          S(:ivar , camelCase(node.children[0]), *node.children[1..-1])
+        else
+          node
+        end
+      end
+
+      def on_cvar(node)
+        node = super
+        return node if node.type != :cvar
+
+        if node.children[0] =~ /_.*\w$/
+          S(:cvar , camelCase(node.children[0]), *node.children[1..-1])
+        else
+          node
+        end
+      end
+
       def on_arg(node)
         node = super
         return node if node.type != :arg
@@ -85,6 +110,28 @@ module Ruby2JS
 
         if node.children[0] =~ /_.*\w$/
           S(:lvasgn , camelCase(node.children[0]), *node.children[1..-1])
+        else
+          node
+        end
+      end
+
+      def on_ivasgn(node)
+        node = super
+        return node if node.type != :ivasgn
+
+        if node.children[0] =~ /_.*\w$/
+          S(:ivasgn , camelCase(node.children[0]), *node.children[1..-1])
+        else
+          node
+        end
+      end
+
+      def on_cvasgn(node)
+        node = super
+        return node if node.type != :cvasgn
+
+        if node.children[0] =~ /_.*\w$/
+          S(:cvasgn , camelCase(node.children[0]), *node.children[1..-1])
         else
           node
         end


### PR DESCRIPTION
It's cool that in es2020+ mode it's able to use the new `#var` proposed ES syntax. Unfortunately, as with many things in the world of JS, the behavior is not at all what I want. This mapping of Ruby's ivars onto private fields breaks the expected behavior of accessing ivars in subclasses—which generally is what I'd always want. (Honestly, I cannot for the life of me understand why a JS subclass shouldn't be able to access its parent class' private fields.)

Thus, this PR adds a new configuration to allow the previous underscoring functionality (`@var` becomes `this._var`) to be used even if es2020+ mode.

I also added a few more node types to camelCase (ivars, etc. weren't getting picked up before).

Let me know what you think!