### PR TITLE
Allow named autoimports and disabling with magic comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,56 @@ the script.
     # => export { one, two, three as default }
     ```
 
+    The esm filter also provides a way to specify "autoimports" when you run the
+    conversion. It will add the relevant import statements automatically whenever
+    a particular class or function name is referenced. These can be either default
+    or named exports. Simply provide an `autoimports` hash with one or more keys
+    to the `Ruby2JS.convert` method. Examples:
+
+    ```ruby
+    require "ruby2js/filter/esm"
+    puts Ruby2JS.convert('class MyElement < LitElement; end',
+      eslevel: 2020, autoimports: {[:LitElement] => "lit-element"})
+    ```
+
+    ```js
+    // JavaScript output:
+    import { LitElement } from "lit-element"
+    class MyElement extends LitElement {}
+    ```
+
+    ```ruby
+    require "ruby2js/filter/esm"
+    puts Ruby2JS.convert('AWN.new({position: "top-right"}).success("Hello World")',
+      eslevel: 2020, autoimports: {:AWN => "awesome-notifications"})
+    ```
+
+    ```js
+    // JavaScript output:
+    import AWN from "awesome-notifications"
+    new AWN({position: "top-right"}).success("Hello World")
+    ```
+
+    The esm filter is able to recognize if you are defining a class or function
+    within the code itself and it won't add that import statement accordingly.
+    If for some reason you wish to disable autoimports entirely on a file-by-file
+    basis (for instance when using the Webpack loader), you can add a magic comment
+    to the top of the code:
+
+    ```ruby
+    require "ruby2js/filter/esm"
+    puts Ruby2JS.convert(
+      "# autoimports: false\n" +
+      'AWN.new({position: "top-right"}).success("Hello World")',
+      eslevel: 2020, autoimports: {:AWN => "awesome-notifications"}
+    )
+    ```
+
+    ```js
+    // autoimports: false
+    new AWN({position: "top-right"}).success("Hello World")
+    ```
+
 * <a id="node" href="https://github.com/rubys/ruby2js/blob/master/spec/node_spec.rb">node</a>
 
     * `` `command` `` becomes `child_process.execSync("command", {encoding: "utf8"})`

--- a/lib/ruby2js/filter/esm.rb
+++ b/lib/ruby2js/filter/esm.rb
@@ -58,8 +58,8 @@ module Ruby2JS
           end
         elsif method == :export          
           s(:export, *process_all(args))
-        elsif target.nil? and args.length == 0 and @esm_autoimports&.[](method)
-          prepend_list << s(:import, @esm_autoimports[method], s(:const, nil, method))
+        elsif target.nil? and found_import = find_autoimport(method)
+          prepend_list << s(:import, found_import[0], found_import[1])
           super
         else
           super
@@ -67,12 +67,27 @@ module Ruby2JS
       end
 
       def on_const(node)
-        if node.children.first == nil and @esm_autoimports&.[](node.children.last)
-          token = node.children.last
-          prepend_list << s(:import, @esm_autoimports[token], s(:const, nil, token))
+        if node.children.first == nil and found_import = find_autoimport(node.children.last)
+          prepend_list << s(:import, found_import[0], found_import[1])
         end
 
         super
+      end
+
+
+    end
+
+    private
+
+    def find_autoimport(token)
+      return nil if @esm_autoimports.nil?
+
+      token = camelCase(token) if respond_to?(:camelCase)
+
+      if @esm_autoimports[token]
+        [@esm_autoimports[token], s(:const, nil, token)]
+      elsif found_key = @esm_autoimports.keys.find {|key| key.is_a?(Array) && key.include?(token)}
+        [@esm_autoimports[found_key], found_key.map {|key| s(:const, nil, key)}]
       end
     end
 

--- a/spec/esm_spec.rb
+++ b/spec/esm_spec.rb
@@ -118,6 +118,25 @@ describe Ruby2JS::Filter::ESM do
       to_js("# autoimports: false\nfunc(1)", autoimports: {[:func, :another] => 'func.js'}).
         must_equal "// autoimports: false\nfunc(1)"
     end
+
+    it "should not autoimport if explicit import is present" do
+      to_js('import Foo from "bar.js"; Foo.bar', autoimports: {Foo: 'foo.js'}).
+        must_equal 'import Foo from "bar.js"; Foo.bar'
+
+      to_js('import Foo, from: "bar.js"; Foo.bar', autoimports: {Foo: 'foo.js'}).
+        must_equal 'import Foo from "bar.js"; Foo.bar'
+    end
+
+    it "should not autoimport if imported name is redefined" do
+      to_js('class Foo;end; Foo.bar', autoimports: {Foo: 'foo.js'}).
+        must_equal 'class Foo {}; Foo.bar'
+
+      to_js('def func(x);end;func(1)', autoimports: {func: 'func.js'}).
+        must_equal 'function func(x) {}; func(1)'
+
+      to_js('func = ->(x) {};func(1)', autoimports: {func: 'func.js'}).
+        must_equal 'let func = (x) => {}; func(1)'
+    end
   end
 
   describe Ruby2JS::Filter::DEFAULTS do

--- a/spec/esm_spec.rb
+++ b/spec/esm_spec.rb
@@ -99,9 +99,24 @@ describe Ruby2JS::Filter::ESM do
         must_equal 'import foo from "foo.js"; foo.bar'
     end
 
+    it "should autoimport for functions" do
+      to_js('func(1)', autoimports: {func: 'func.js'}).
+        must_equal 'import func from "func.js"; func(1)'
+    end
+
     it "should handle autoimport as a proc" do
       to_js('Foo.bar', autoimports: proc {|name| "#{name.downcase}.js"}).
         must_equal 'import Foo from "foo.js"; Foo.bar'
+    end
+
+    it "should allow named autoimports" do
+      to_js('func(1)', autoimports: {[:func, :another] => 'func.js'}).
+        must_equal 'import { func, another } from "func.js"; func(1)'
+    end
+
+    it "should not autoimport if magic comment is present" do
+      to_js("# autoimports: false\nfunc(1)", autoimports: {[:func, :another] => 'func.js'}).
+        must_equal "// autoimports: false\nfunc(1)"
     end
   end
 


### PR DESCRIPTION
I added a couple new features to your very cool autoimports setup @rubys, and I think it's in good shape but wanted a second pair of eyes to make sure I'm not overlooking anything.

What I did was:

* Made it work with any function call with args, not just `foo.bar`
* Made it work with named imports via array-based keys (so similar concept to how named imports are done manually)
* Added an `autoimports: false` magic comment so individual files can opt-out if need be—very useful in a Webpack setting

Let me know what you think!